### PR TITLE
Implementation Issue #12 - Log stdout from new process

### DIFF
--- a/src/launcher/Logging.java
+++ b/src/launcher/Logging.java
@@ -98,7 +98,7 @@ public class Logging {
 			logDebug("Exit due to exception, see: '" + exceptionFile.getAbsolutePath() + "'");
 			e.printStackTrace(ps);
 			statusListener.setStatusCompletedExecCommandOnExit(null);
-			JOptionPane.showMessageDialog(null, "Exception see '" + exceptionFile.getAbsolutePath() + "'");
+			JOptionPane.showMessageDialog(null, "Error see '" + exceptionFile.getAbsolutePath() + "'", "Error", JOptionPane.ERROR_MESSAGE);
 			System.exit(99);
 		}
 	}

--- a/src/launcher/Logging.java
+++ b/src/launcher/Logging.java
@@ -7,6 +7,8 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.UUID;
 
+import javax.swing.JOptionPane;
+
 import launcher.gui.IStatusListener;
 
 /**
@@ -93,9 +95,11 @@ public class Logging {
 		} catch (FileNotFoundException e1) {
 			e1.printStackTrace();
 		} finally {
-			logDebug("Stop due to exception, see: '" + exceptionFile.getAbsolutePath() + "'");
+			logDebug("Exit due to exception, see: '" + exceptionFile.getAbsolutePath() + "'");
 			e.printStackTrace(ps);
 			statusListener.setStatusCompletedExecCommandOnExit(null);
+			JOptionPane.showMessageDialog(null, "Exception see '" + exceptionFile.getAbsolutePath() + "'");
+			System.exit(99);
 		}
 	}
 	

--- a/src/launcher/gui/StatusDisplay.java
+++ b/src/launcher/gui/StatusDisplay.java
@@ -20,6 +20,7 @@ import javax.swing.JPanel;
 import javax.swing.JProgressBar;
 import javax.swing.JScrollPane;
 import javax.swing.JTextArea;
+import javax.swing.SwingWorker;
 import javax.swing.text.DefaultCaret;
 
 /**
@@ -160,9 +161,7 @@ public class StatusDisplay extends JFrame implements IStatusListener, ActionList
 	@Override
 	public void actionPerformed(ActionEvent e) {
 		if (e.getSource() == closeButton) {
-			if (exitRunner != null)
-				exitRunner.run();
-			dispose();
+			new RunWorker().execute();
 		}
 	}
 	
@@ -195,4 +194,20 @@ public class StatusDisplay extends JFrame implements IStatusListener, ActionList
 		setCurrentProgress("Done!");
 	}
 	
+	
+	private class RunWorker extends SwingWorker<Void, Void> {
+
+		@Override
+		protected Void doInBackground() throws Exception {
+			if (exitRunner != null) {
+				exitRunner.run();
+			}
+			return null;
+		}
+		
+		@Override
+		protected void done() {
+			dispose();
+		}
+	}
 }


### PR DESCRIPTION
Description:
POST_CMD process output is currently not seen.
Log it as all other output to the display and the log file.

Resolution:
POST_CMD now executed on another thread so the launcher
will not freeze.
Log stdout from subprocess cancelled.
This would lead to the launcher not being able to close after
starting POST_CMD process.
The process started should take care itself about logging.
If a shell script or kinda things shall be executed it would be better
to redirect the output from within the script.
